### PR TITLE
BTA-7189 Regenerate SDK with `1.17.0` version which introduces the new `TransferReason` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.transferzero.sdk</groupId>
   <artifactId>transferzero-sdk-java8</artifactId>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.transferzero.sdk:transferzero-sdk-java8:1.16.1-SNAPSHOT"
+compile "com.transferzero.sdk:transferzero-sdk-java8:1.17.0-SNAPSHOT"
 ```
 
 ### Others
@@ -68,7 +68,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/transferzero-sdk-java8-1.16.1-SNAPSHOT.jar`
+* `target/transferzero-sdk-java8-1.17.0-SNAPSHOT.jar`
 * `target/lib/*.jar`
 
 ## Getting Started
@@ -238,6 +238,7 @@ Class | Method | HTTP request | Description
  - [PayoutMethodNatureOfBusinessEnum](docs/PayoutMethodNatureOfBusinessEnum.md)
  - [PayoutMethodRequest](docs/PayoutMethodRequest.md)
  - [PayoutMethodResponse](docs/PayoutMethodResponse.md)
+ - [PayoutMethodTransferReasonEnum](docs/PayoutMethodTransferReasonEnum.md)
  - [PayoutMethodWebhook](docs/PayoutMethodWebhook.md)
  - [PoliticallyExposedPerson](docs/PoliticallyExposedPerson.md)
  - [ProofOfPayment](docs/ProofOfPayment.md)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'com.transferzero.sdk'
-version = '1.16.1-SNAPSHOT'
+version = '1.17.0-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.transferzero.sdk",
     name := "transferzero-sdk-java8",
-    version := "1.16.1-SNAPSHOT",
+    version := "1.17.0-SNAPSHOT",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>transferzero-sdk-java8</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java8</name>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java8</url>
     <description>Java 8 library for the TransferZero API</description>
     <scm>

--- a/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsKESBankTest.java
+++ b/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsKESBankTest.java
@@ -19,6 +19,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.transferzero.sdk.model.PayoutMethodIdentityCardTypeEnum;
+import com.transferzero.sdk.model.PayoutMethodTransferReasonEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
@@ -111,6 +112,14 @@ public class PayoutMethodDetailsKESBankTest {
     @Test
     public void transferReasonCodeTest() {
         // TODO: test transferReasonCode
+    }
+
+    /**
+     * Test the property 'transferReason'
+     */
+    @Test
+    public void transferReasonTest() {
+        // TODO: test transferReason
     }
 
     /**

--- a/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsKESMobileTest.java
+++ b/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsKESMobileTest.java
@@ -20,6 +20,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.transferzero.sdk.model.PayoutMethodIdentityCardTypeEnum;
 import com.transferzero.sdk.model.PayoutMethodMobileProviderEnum;
+import com.transferzero.sdk.model.PayoutMethodTransferReasonEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
@@ -88,6 +89,14 @@ public class PayoutMethodDetailsKESMobileTest {
     @Test
     public void transferReasonCodeTest() {
         // TODO: test transferReasonCode
+    }
+
+    /**
+     * Test the property 'transferReason'
+     */
+    @Test
+    public void transferReasonTest() {
+        // TODO: test transferReason
     }
 
     /**

--- a/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsTest.java
+++ b/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsTest.java
@@ -43,6 +43,7 @@ import com.transferzero.sdk.model.PayoutMethodIdentityCardTypeEnum;
 import com.transferzero.sdk.model.PayoutMethodLegalEntityTypeEnum;
 import com.transferzero.sdk.model.PayoutMethodMobileProviderEnum;
 import com.transferzero.sdk.model.PayoutMethodNatureOfBusinessEnum;
+import com.transferzero.sdk.model.PayoutMethodTransferReasonEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;

--- a/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsXOFBankTest.java
+++ b/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsXOFBankTest.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.transferzero.sdk.model.PayoutMethodTransferReasonEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
@@ -86,6 +87,14 @@ public class PayoutMethodDetailsXOFBankTest {
     @Test
     public void bankCodeTest() {
         // TODO: test bankCode
+    }
+
+    /**
+     * Test the property 'transferReason'
+     */
+    @Test
+    public void transferReasonTest() {
+        // TODO: test transferReason
     }
 
 }

--- a/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsZARBankTest.java
+++ b/src/test/java/com/transferzero/sdk/model/PayoutMethodDetailsZARBankTest.java
@@ -20,6 +20,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.transferzero.sdk.model.PayoutMethodLegalEntityTypeEnum;
 import com.transferzero.sdk.model.PayoutMethodNatureOfBusinessEnum;
+import com.transferzero.sdk.model.PayoutMethodTransferReasonEnum;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
@@ -120,6 +121,14 @@ public class PayoutMethodDetailsZARBankTest {
     @Test
     public void transferReasonCodeTest() {
         // TODO: test transferReasonCode
+    }
+
+    /**
+     * Test the property 'transferReason'
+     */
+    @Test
+    public void transferReasonTest() {
+        // TODO: test transferReason
     }
 
     /**


### PR DESCRIPTION
BTA-7189: Regenerate SDK with `1.17.0` version which introduces the new `TransferReason` field