### PR TITLE
BTA-16033 Bump pom.xml version to 1.37.5-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>transferzero-sdk-java8</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java8</name>
-    <version>1.37.4-SNAPSHOT</version>
+    <version>1.37.5-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java8</url>
     <description>Java 8 library for the TransferZero API</description>
     <scm>


### PR DESCRIPTION
## Summary
- Bump `pom.xml` `<version>` from `1.37.4-SNAPSHOT` → `1.37.5-SNAPSHOT`.

## Why
`1.37.4` is already published on Maven Central, so a fresh `release.yml` run with `tag_name=1.37.5` is needed for the next release (which carries the `mandate_id` field added to `Recipient` via api-specification PR #422).

`pom.xml` is registered as a "supporting file" by openapi-generator 4.0.0-beta3 and never overwritten by CodeBuild's regeneration (log line: `Skipped overwriting pom.xml as the file already exists`). So bumping `artifactVersion` in `bitpesa-api-specification/swagger-config/config-java8.json` (PR #423 there) only updated the User-Agent string — the `<version>` in pom.xml has to be bumped manually here, same pattern as PR #84.

## Test plan
- [ ] Merge to master.
- [ ] `gh workflow run release.yml --repo transferzero/transferzero-sdk-java8 -f tag_name=1.37.5 --ref master` succeeds: artifacts upload + staging close on Sonatype Central.
- [ ] `https://repo1.maven.org/maven2/com/transferzero/sdk/transferzero-sdk-java8/1.37.5/` lists the new artifacts.
- [ ] Decompiled `Recipient.class` includes the `mandateId` field.
