### PR TITLE
Bump SDK version to 1.37.9-SNAPSHOT for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.transferzero.sdk</groupId>
   <artifactId>transferzero-sdk-java8</artifactId>
-  <version>1.37.8-SNAPSHOT</version>
+  <version>1.37.9-SNAPSHOT</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.transferzero.sdk:transferzero-sdk-java8:1.37.8-SNAPSHOT"
+compile "com.transferzero.sdk:transferzero-sdk-java8:1.37.9-SNAPSHOT"
 ```
 
 ### Others
@@ -68,7 +68,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/transferzero-sdk-java8-1.37.8-SNAPSHOT.jar`
+* `target/transferzero-sdk-java8-1.37.9-SNAPSHOT.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'com.transferzero.sdk'
-version = '1.37.8-SNAPSHOT'
+version = '1.37.9-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.transferzero.sdk",
     name := "transferzero-sdk-java8",
-    version := "1.37.8-SNAPSHOT",
+    version := "1.37.9-SNAPSHOT",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>transferzero-sdk-java8</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java8</name>
-    <version>1.37.8-SNAPSHOT</version>
+    <version>1.37.9-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java8</url>
     <description>Java 8 library for the TransferZero API</description>
     <scm>


### PR DESCRIPTION
## Summary

Manual `pom.xml` / README / build.gradle / build.sbt bump to `1.37.9-SNAPSHOT` in preparation for the 1.37.9 release.

1.37.8 Java release.yml failed at `mvn compile` because the generated `MandateResponse.java` referenced `HashMap` without an import (consequence of `additionalProperties: true` on `Mandate`). bitpesa-api-specification PR #429 drops `additionalProperties` from the schema. 1.37.9 is the clean re-release.

## Test plan

- [ ] Admin-merge
- [ ] `gh workflow run release.yml --ref master -f tag_name=v1.37.9`
- [ ] Maven Central HEAD on `transferzero-sdk-java{7,8}-1.37.9.pom` returns 200
- [ ] `mvn compile` succeeds — Mandate is now a plain POJO
